### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ See Babel's documentation on [plugins](https://babeljs.io/docs/advanced/plugins/
 ```json
 {
   "optional": ["es7.decorators"],
-  "plugins": ["babel-plugin-remove-decorator:before"]
+  "plugins": ["remove-decorators:before"]
 }
 
 ```


### PR DESCRIPTION
Typo in documentation:
1. does not need the `babel-plugin` prefix
2. it's decorator**s** with an `s` at the end, not `decorator`
